### PR TITLE
Dynamically set debug and security relevant environment variables

### DIFF
--- a/voluncheer/voluncheer/settings.py
+++ b/voluncheer/voluncheer/settings.py
@@ -23,19 +23,24 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = "django-insecure-snh-g_^mv%l437fv(^*#%hzl!p2bf7++q#5a-#9+lqu5yv$$yw"
 
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+# CSRF_TRUSTED_ORIGINS = [
+#     "voluncheer-dev.us-west-2.elasticbeanstalk.com",
+# ]
+# ALLOWED_HOSTS = [
+#     "voluncheer-dev.us-west-2.elasticbeanstalk.com",
+# ]
+# Security
+CSRF_TRUSTED_ORIGINS = ["http://localhost", "http://127.0.0.1"]
+_CSRF_TRUSTED_ORIGINS_CSV = os.getenv("CSRF_TRUSTED_ORIGINS_CSV")
+if _CSRF_TRUSTED_ORIGINS_CSV:
+    CSRF_TRUSTED_ORIGINS = _CSRF_TRUSTED_ORIGINS_CSV.split(",")
 
-CSRF_TRUSTED_ORIGINS = [
-    "voluncheer-dev.us-west-2.elasticbeanstalk.com",
-]
-ALLOWED_HOSTS = [
-    "voluncheer-dev.us-west-2.elasticbeanstalk.com",
-]
-
+ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
+_ALLOWED_HOSTS_CSV = os.getenv("ALLOWED_HOSTS_CSV")
+if _ALLOWED_HOSTS_CSV:
+    ALLOWED_HOSTS = _ALLOWED_HOSTS_CSV.split(",")
 
 # Application definition
-
 INSTALLED_APPS = [
     # Django built-ins
     "django.contrib.admin",
@@ -45,7 +50,6 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     # External applications
-    "debug_toolbar",
     "crispy_forms",
     "crispy_bootstrap5",
     # Local applications
@@ -63,11 +67,6 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    # You should include the Debug Toolbar middleware as early as possible in
-    # the list.
-    # However, it must come after any other middleware that encodes the
-    # response’s content, such as GZipMiddleware.
-    "debug_toolbar.middleware.DebugToolbarMiddleware",
 ]
 
 ROOT_URLCONF = "voluncheer.urls"
@@ -75,11 +74,12 @@ ROOT_URLCONF = "voluncheer.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        'DIRS': [(os.path.join(BASE_DIR, 'templates')),],
+        "DIRS": [
+            (os.path.join(BASE_DIR, "templates")),
+        ],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
-                "django.template.context_processors.debug",
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
@@ -149,12 +149,22 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # Authentication and authorization
 AUTH_USER_MODEL = "profiles.User"
-LOGIN_URL = 'login'
-LOGOUT_URL = 'logout'
-LOGIN_REDIRECT_URL = 'home'
-LOGOUT_REDIRECT_URL = 'home'
+LOGIN_URL = "login"
+LOGOUT_URL = "logout"
+LOGIN_REDIRECT_URL = "home"
+LOGOUT_REDIRECT_URL = "home"
 ACCOUNT_USERNAME_REQUIRED = False
 
 # Crispy Forms
 CRISPY_ALLOWED_TEMPLATE_PACKS = "bootstrap5"
 CRISPY_TEMPLATE_PACK = "bootstrap5"
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = os.getenv("IS_PRODUCTION") != "true"
+
+if DEBUG:
+    INSTALLED_APPS.append("debug_toolbar")
+    MIDDLEWARE.append("debug_toolbar.middleware.DebugToolbarMiddleware")
+    TEMPLATES[0].get("OPTIONS", {}).get("context_processors", []).append(
+        "django.template.context_processors.debug"
+    )


### PR DESCRIPTION
This change dynamically adds the debugging tooling when the environment variable `IS_PRODUCTION` is not set to `true`. Thus when running in production we must set `IS_PRODUCTION=true` in the environment.

In addition, this adds the ability to set the CSRF trusted origins and allowed hosts dynamically via comma separated environment variables.