### PR TITLE
Update coveralls to use the v2 action

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -20,7 +20,7 @@ runs:
         coverage lcov --fail-under=${{ inputs.minimum-coverage }}
     - name: Report Coverage to Coveralls
       if: ${{ success() }}
-      uses: coverallsapp/github-action@v1
+      uses: coverallsapp/github-action@v2
       with:
         base-path: voluncheer
         github-token: ${{ github.token }}


### PR DESCRIPTION
Using the `v2` GitHub action version is supposed to fix the error we are getting on post submit runs on main:

```
Error: Command failed: git cat-file -p 54f99fbb185008af3eae35e04dfb5e420b19a2a1 fatal: Not a valid object name 54f99fbb185008af3eae35e04dfb5e420b19a2a1
```