### PR TITLE
fixed end_date bug

### DIFF
--- a/voluncheer/opportunityboard/forms/postanopportunity.py
+++ b/voluncheer/opportunityboard/forms/postanopportunity.py
@@ -26,7 +26,7 @@ class PostAnOpportunityForm(forms.ModelForm):
     )
 
     end_date = forms.DateField(
-        input_formats=["%d/%m/%Y"],
+        input_formats=["%Y-%m-%d"],
         widget=forms.DateInput(
             attrs={
                 "type": "date",


### PR DESCRIPTION
This is a one-line change to address a bug with `end_date` field in the `PostAnOpportunityForm`, which corrects the format in which the date is submitted.

Not entirely sure why the DateField is complaining about the date in a d-m-y format, but changing it to y-m-d resolved the issue. This doesn't affect how it displays to the user/on the form.