### PR TITLE
Added pull_nyc_charities to django.config

### DIFF
--- a/voluncheer/.ebextensions/django.config
+++ b/voluncheer/.ebextensions/django.config
@@ -2,6 +2,9 @@ container_commands:
   01_migrate:
     command: "source /var/app/venv/*/bin/activate && python3 manage.py migrate"
     leader_only: true
+  02_pull_data:
+    command: "source /var/app/venv/*/bin/activate && python3 manage.py pull_nyc_charities"
+    leader_only: true
 option_settings:
   aws:elasticbeanstalk:application:environment:
     DJANGO_SETTINGS_MODULE: voluncheer.settings


### PR DESCRIPTION
This pr runs the pull_nyc_charities command at deployment so that we can have access to the charities.