### PR TITLE
Add date validation (and requirement) for opportunities.

### DIFF
--- a/voluncheer/opportunityboard/forms/postanopportunity.py
+++ b/voluncheer/opportunityboard/forms/postanopportunity.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django import forms
 from django.core.exceptions import ValidationError
 
@@ -16,6 +18,7 @@ class PostAnOpportunityForm(forms.ModelForm):
                 "type": "datetime-local",
             }
         ),
+        required=True,
     )
     end = forms.TimeField(
         widget=forms.TimeInput(
@@ -120,6 +123,8 @@ class PostAnOpportunityForm(forms.ModelForm):
             raise ValidationError("Must enter recurrence if opportunity is recurring")
 
         date = self.cleaned_data.get("date")
+        if date < datetime.datetime.now(tz=date.tzinfo):
+            raise ValidationError("Start date and time must be in the future.")
         start_time = date.time()
         end_time = self.cleaned_data.get("end")
 

--- a/voluncheer/opportunityboard/test_forms.py
+++ b/voluncheer/opportunityboard/test_forms.py
@@ -1,3 +1,7 @@
+import datetime
+
+import freezegun
+
 from opportunityboard.forms.postanopportunity import PostAnOpportunityForm
 from opportunityboard.models import Category
 from opportunityboard.models import Opportunity
@@ -35,6 +39,23 @@ class PostAnOpportunityFormTest(TestCase):
         self.assertEqual(posted_opportunity.title, "Sith Surfing")
         self.assertEqual(posted_opportunity.category.name, "healthcare")
         self.assertEqual(posted_opportunity.description, "Let's surfing")
+
+    def test_date_validation(self):
+        data = {
+            "organization": self.org,
+            "category": self.healthcare,
+            "title": "Sith Surfing",
+            "description": "Let's surfing",
+            "staffing": "1",
+            "date": self.date,
+            "end": self.end,
+            "address_1": "New York, NY",
+            "address_2": "Down st",
+            "is_published": False,
+        }
+        with freezegun.freeze_time(self.date + datetime.timedelta(days=1)):
+            form = PostAnOpportunityForm(data=data)
+            self.assertFalse(form.is_valid())
 
     def test_update(self):
         """Test Update An Opportunity validation"""


### PR DESCRIPTION
This PR makes the start date/time required when creating an opportunity and adds validation ensuring the event starts in the future.