### PR TITLE
Do not show opportunities before now on the opportunity board.

### DIFF
--- a/voluncheer/opportunityboard/tests_views.py
+++ b/voluncheer/opportunityboard/tests_views.py
@@ -1,8 +1,9 @@
-import datetime as dt
+import datetime
 
 from django.contrib.auth import get_user_model
 from django.test.client import RequestFactory
 from django.urls import reverse
+import freezegun
 
 from opportunityboard.models import Category
 from opportunityboard.unittest_setup import TestCase
@@ -49,6 +50,12 @@ class OpportunityboardTestCase(TestCase):
         response = opportunityboard(get_request, 1)
         self.assertEqual(response.status_code, 200)
 
+    def test_search_excludes_opportunities_before_now(self):
+        """Tests that opportunities before now are not returned."""
+        with freezegun.freeze_time(self.date + datetime.timedelta(days=1)):
+            filters = Filter()
+            self.assertEqual(filters.search().count(), 0)
+
     def test_search_by_categories(self):
         """Tests filter search by category/subcategory/subsubcategory functions"""
         filters = Filter()
@@ -70,13 +77,13 @@ class OpportunityboardTestCase(TestCase):
         opp_pk = self.opp.pk
 
         with self.subTest("two hours"):
-            self.opp.end = dt.time(2, 0, 0)
+            self.opp.end = datetime.time(2, 0, 0)
             self.opp.save()
             opp_list = filters.search()
             self.assertTrue(opp_list.filter(pk=opp_pk).exists())
 
         with self.subTest("over two hours"):
-            self.opp.end = dt.time(2, 1, 0)
+            self.opp.end = datetime.time(2, 1, 0)
             self.opp.save()
             opp_list = filters.search()
             self.assertFalse(opp_list.filter(pk=opp_pk).exists())
@@ -87,13 +94,13 @@ class OpportunityboardTestCase(TestCase):
         opp_pk = self.opp.pk
 
         with self.subTest("four hours"):
-            self.opp.end = dt.time(4, 0, 0)
+            self.opp.end = datetime.time(4, 0, 0)
             self.opp.save()
             opp_list = filters.search()
             self.assertTrue(opp_list.filter(pk=opp_pk).exists())
 
         with self.subTest("over four hours"):
-            self.opp.end = dt.time(4, 1, 0)
+            self.opp.end = datetime.time(4, 1, 0)
             self.opp.save()
             opp_list = filters.search()
             self.assertFalse(opp_list.filter(pk=opp_pk).exists())
@@ -104,13 +111,13 @@ class OpportunityboardTestCase(TestCase):
         opp_pk = self.opp.pk
 
         with self.subTest("eight hours"):
-            self.opp.end = dt.time(8, 0, 0)
+            self.opp.end = datetime.time(8, 0, 0)
             self.opp.save()
             opp_list = filters.search()
             self.assertTrue(opp_list.filter(pk=opp_pk).exists())
 
         with self.subTest("over eight hours"):
-            self.opp.end = dt.time(8, 1, 0)
+            self.opp.end = datetime.time(8, 1, 0)
             self.opp.save()
             opp_list = filters.search()
             self.assertFalse(opp_list.filter(pk=opp_pk).exists())

--- a/voluncheer/opportunityboard/views/search.py
+++ b/voluncheer/opportunityboard/views/search.py
@@ -1,4 +1,4 @@
-import datetime as dt
+import datetime
 
 from geopy import distance
 
@@ -68,6 +68,7 @@ class Filter:
         """
         filtered_opportunity = Opportunity.objects.all()
         filtered_opportunity = filtered_opportunity.exclude(staffing=0)
+        filtered_opportunity = filter_opportunities_before_now(filtered_opportunity)
         if self.category is not None:
             filtered_opportunity = filtered_opportunity.filter(category=self.category)
         if self.subcategory is not None:
@@ -87,6 +88,14 @@ class Filter:
         return filtered_opportunity
 
 
+def filter_opportunities_before_now(queryset):
+    now = datetime.datetime.now().timestamp()
+    for opportunity in queryset:
+        if opportunity.date <= datetime.datetime.fromtimestamp(now, tz=opportunity.date.tzinfo):
+            queryset = queryset.exclude(pk=opportunity.pk)
+    return queryset
+
+
 def filter_by_distance(queryset, location, max_distance):
     for opportunity in queryset:
         opportunity_location = (opportunity.latitude, opportunity.longitude)
@@ -100,7 +109,7 @@ def filter_by_duration(queryset, max):
     Takes Opportunity queryset and a max number of hours.
     Returns Opportunity queryset with durations less than or equal to the max.
     """
-    max_duration = dt.timedelta(hours=max)
+    max_duration = datetime.timedelta(hours=max)
     for opportunity in queryset:
         if opportunity.duration > max_duration:
             queryset = queryset.exclude(pk=opportunity.pk)


### PR DESCRIPTION
This PR stops opportunities that start now or in the past from displaying on the opportunity board to prevent users from seeing opportunities they effectively cannot participate in given the arrow of time.